### PR TITLE
Doc: mention better and future software

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ See `/camera/hardware` folder for more info
 ### Disclaimer
 
 The 5V 1A micro usb charger's discharge cut off is very low around 2.5V, keep that in mind depending on your battery.
+
+### Note
+
+Refer to the [modular pi cam's software](https://github.com/jdc-cunningham/modular-pi-cam/tree/master/cameras/pi-zero/large-display/software) which is more current than this.
+
+Eventually [pelicam](https://github.com/jdc-cunningham/pelicam) will be the general purpose DIY camera software


### PR DESCRIPTION
Modular pi cam supports different cameras eg. v3 module and HQ cam

Modular pi cam also has a different display type however the GUI is not dynamically rendered that's something pelicam would address but I've been sidetracked by life

Pi zero hq cam's software is buggy (have to restart it) and this was addressed on mpi-cam side particularly this [PR](https://github.com/jdc-cunningham/modular-pi-cam/pull/8)

Video mode is still buggy right now but I'm reworking that to add live preview